### PR TITLE
Add VLAI attributes to NVD and OSV entities

### DIFF
--- a/knowledge_db/nvd.go
+++ b/knowledge_db/nvd.go
@@ -20,6 +20,8 @@ type NVDItem struct {
 	LastModified      string          `bun:"lastModified"`
 	VulnStatus        string          `bun:"vulnStatus"`
 	Descriptions      []Descriptions  `bun:"descriptions"`
+	Vlai_score        string          `bun:"vlai_score"`
+	Vlai_confidence   float64         `bun:"vlai_confidence"`
 	Metrics           Metrics         `bun:"metrics"`
 	Weaknesses        []Weaknesses    `bun:"weaknesses"`
 	Configurations    []Configuration `bun:"configurations"`

--- a/knowledge_db/osv.go
+++ b/knowledge_db/osv.go
@@ -10,6 +10,8 @@ type OSVItem struct {
 	Id               uuid.UUID      `bun:",pk,autoincrement,type:uuid,default:uuid_generate_v4()"`
 	OSVId            string         `json:"id" bun:"osv_id"`
 	Schema_version   string         `json:"schema_version" bun:"schema_version"`
+	Vlai_score       string         `bun:"vlai_score"`
+	Vlai_confidence  float64        `bun:"vlai_confidence"`
 	Modified         string         `json:"modified" bun:"modified"`
 	Published        string         `json:"published" bun:"published"`
 	Withdrawn        string         `json:"withdrawn" bun:"withdrawn"`


### PR DESCRIPTION
Introduce `vlai_score` and `vlai_confidence` attributes to enhance the NVD and OSV data models.