### PR TITLE
Add EPSS type and update bun dependency to v1.2.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.3
 require (
 	github.com/google/uuid v1.6.0
 	github.com/schollz/progressbar/v3 v3.18.0
-	github.com/uptrace/bun v1.2.13
+	github.com/uptrace/bun v1.2.14
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc h1:9lRDQMhESg+zvGYmW5DyG0UqvY96Bu5QYsTLvCHdrgo=
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc/go.mod h1:bciPuU6GHm1iF1pBvUfxfsH0Wmnc2VbpgvbI9ZWuIRs=
-github.com/uptrace/bun v1.2.13 h1:tFJjT+mIrogD/mgwwS3lUJmd8Z7M63oZYS1dl6f+23w=
-github.com/uptrace/bun v1.2.13/go.mod h1:ZS4nPaEv2Du3OFqAD/irk3WVP6xTB3/9TWqjJbgKYBU=
+github.com/uptrace/bun v1.2.14 h1:5yFSfi/yVWEzQ2lAaHz+JfWN9AHmqYtNmlbaUbAp3rU=
+github.com/uptrace/bun v1.2.14/go.mod h1:ZS4nPaEv2Du3OFqAD/irk3WVP6xTB3/9TWqjJbgKYBU=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/knowledge_db/epss.go
+++ b/knowledge_db/epss.go
@@ -1,0 +1,14 @@
+package knowledge
+
+import (
+	"github.com/google/uuid"
+	"github.com/uptrace/bun"
+)
+
+type EPSS struct {
+	bun.BaseModel `bun:"table:epss,alias:n"`
+	Id            uuid.UUID `bun:",pk,autoincrement,type:uuid,default:uuid_generate_v4()"`
+	CVE           string    `bun:"cve" json:"cve"`
+	Score         float32   `bun:"score" json:"score"`
+	Percentile    float32   `bun:"percentile" json:"percentile"`
+}


### PR DESCRIPTION
Introduce a new EPSS type for managing vulnerability data and update the bun dependency to the latest version for improved functionality.