### PR TITLE
Refactor Credit type to use a single string for Type with custom JSON unmarshaler

### DIFF
--- a/knowledge_db/osv.go
+++ b/knowledge_db/osv.go
@@ -1,6 +1,9 @@
 package knowledge
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/google/uuid"
 	"github.com/uptrace/bun"
 )
@@ -70,5 +73,23 @@ type Reference struct {
 type Credit struct {
 	Name    string   `json:"name"`
 	Contact []string `json:"contact"`
-	Type    []string `json:"type"`
+	Type    string   `json:"type"`
+}
+
+// Custom unmarshaler for Credit to handle both single string and slice of strings
+func (c *Credit) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Name    string   `json:"name"`
+		Contact []string `json:"contact"`
+		Type    string   `json:"type"`
+	}
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("invalid format for Credit: %s", string(data))
+	}
+
+	c.Name = raw.Name
+	c.Contact = raw.Contact
+	c.Type = raw.Type
+	return nil
 }


### PR DESCRIPTION
Change the Credit struct to use a single string for the Type field and implement a custom JSON unmarshaler to support both single strings and slices of strings.